### PR TITLE
Add support for Rails 7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ with the same intent.
 
 ## Fork differences
 
-- Added support for Rails 5.1 and 6.0
+- Added support for Rails 5.1, 6, and 7
 - Removed support for Rails <5.1
 
 ### Breaking changes

--- a/lib/fuzzily/searchable.rb
+++ b/lib/fuzzily/searchable.rb
@@ -5,10 +5,7 @@ module Fuzzily
   module Searchable
 
     def self.included(by)
-      case ActiveRecord::VERSION::MAJOR
-        when 5 then by.extend Rails5ClassMethods
-        when 6 then by.extend Rails6ClassMethods
-      end
+      by.extend ClassMethods
     end
 
     private
@@ -149,12 +146,6 @@ module Fuzzily
         class_variable_set(:"@@fuzzily_searchable_#{field}", true)
         self
       end
-    end
-
-    module Rails5ClassMethods
-      include ClassMethods
-
-      private
 
       def _add_trigram_association(_o)
         has_many _o.trigram_association,
@@ -168,10 +159,6 @@ module Fuzzily
       def _with_included_trigrams(_o)
         self.includes(_o.trigram_association)
       end
-    end
-
-    module Rails6ClassMethods
-      include Rails5ClassMethods
     end
   end
 end

--- a/lib/fuzzily/version.rb
+++ b/lib/fuzzily/version.rb
@@ -1,3 +1,3 @@
 module Fuzzily
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
The `searchable` module broke on Rails 7 because it was explicitly looking for Rails 5 or 6. The behavior was actually the same between 5 and 6, and works the same way on Rails 7, so I've simplified the logic for which class methods to include: all of them. Rails versions older than 5.1 are already incompatible with the gemspec, so this change should keep the gem working through major version changes in the future.

Resolves #1 